### PR TITLE
fix: add missing key field for host configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -188,6 +188,7 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'host',
+            key: 'host',
             value: 'chat.jandebelastingman.nl'
           }
         ]
@@ -199,6 +200,7 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'host',
+            key: 'host',
             value: 'chat.jandebelastingman.nl'
           }
         ]
@@ -210,6 +212,7 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'host',
+            key: 'host',
             value: 'chat.jandebelastingman.nl'
           }
         ]
@@ -221,6 +224,7 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'host',
+            key: 'host',
             value: 'chat.jandebelastingman.nl'
           }
         ]
@@ -232,6 +236,7 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'host',
+            key: 'host',
             value: 'chat.jandebelastingman.nl'
           }
         ]


### PR DESCRIPTION
Add the missing 'key' field to host configurations in  next.config.ts for the host 'chat.jandebelastingman.nl'.  This change ensures proper identification and processing  of host configurations in the application.