### PR TITLE
feat: add sitemap and robots.txt generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://jandebelastingman.nl';
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/*', '/admin/*'],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+} 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,71 @@
+import { chatENToDictionaryKey, routes, topicENToDictionaryKey } from '@/lib/routes';
+import { MetadataRoute } from 'next';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://jandebelastingman.nl';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const currentDate = new Date();
+  const sitemapEntries: MetadataRoute.Sitemap = [];
+
+  // Add main pages
+  const mainPages = [
+    { key: 'home', nl: '', en: '' },
+    { key: 'how-it-works', nl: routes['how-it-works'].nl, en: routes['how-it-works'].en },
+    { key: 'blog', nl: routes['blog'].nl, en: routes['blog'].en },
+    { key: 'about-us', nl: routes['about-us'].nl, en: routes['about-us'].en },
+    { key: 'find-advisor', nl: routes['find-advisor'].nl, en: routes['find-advisor'].en },
+  ];
+
+  mainPages.forEach(({ key, nl, en }) => {
+    sitemapEntries.push({
+      url: `${BASE_URL}${nl ? `/${nl}` : ''}`,
+      lastModified: currentDate,
+      changeFrequency: 'daily',
+      priority: key === 'home' ? 1 : 0.8,
+      alternates: {
+        languages: {
+          nl: `${BASE_URL}${nl ? `/${nl}` : ''}`,
+          en: `${BASE_URL}/en${en ? `/${en}` : ''}`,
+        },
+      },
+    });
+  });
+
+  // Add topic pages
+  Object.entries(topicENToDictionaryKey).forEach(([topicKey, dictionaryKey]) => {
+    if (routes[dictionaryKey] && routes['topics']) {
+      sitemapEntries.push({
+        url: `${BASE_URL}/${routes['topics'].nl}/${routes[dictionaryKey].nl}`,
+        lastModified: currentDate,
+        changeFrequency: 'weekly',
+        priority: 0.7,
+        alternates: {
+          languages: {
+            nl: `${BASE_URL}/${routes['topics'].nl}/${routes[dictionaryKey].nl}`,
+            en: `${BASE_URL}/en/${routes['topics'].en}/${routes[dictionaryKey].en}`,
+          },
+        },
+      });
+    }
+  });
+
+  // Add chat pages
+  Object.entries(chatENToDictionaryKey).forEach(([chatKey, dictionaryKey]) => {
+    if (routes[dictionaryKey] && routes['chat']) {
+      sitemapEntries.push({
+        url: `${BASE_URL}/${routes['chat'].nl}/${routes[dictionaryKey].nl}`,
+        lastModified: currentDate,
+        changeFrequency: 'weekly',
+        priority: 0.6,
+        alternates: {
+          languages: {
+            nl: `${BASE_URL}/${routes['chat'].nl}/${routes[dictionaryKey].nl}`,
+            en: `${BASE_URL}/en/${routes['chat'].en}/${routes[dictionaryKey].en}`,
+          },
+        },
+      });
+    }
+  });
+
+  return sitemapEntries;
+} 


### PR DESCRIPTION
Introduce a dynamic sitemap and robots.txt generation to improve 
SEO and crawlability. The sitemap includes main, topic, and chat 
pages, each with appropriate metadata for search engines. The 
robots.txt file specifies allowable and disallowed paths for 
crawlers while linking to the new sitemap.