### PR TITLE
feat: add URLs to partner images and update routing logic

### DIFF
--- a/app/chat/dictionary.ts
+++ b/app/chat/dictionary.ts
@@ -3,14 +3,14 @@ import { SupportedLocale } from "@/lib/types";
 import chatDictionaries from "./dictionaries.json";
 
 interface ChatSpecificDictionary {
-  assistantId: number;
-  assistantName: string;
-  assistantDescription: string;
   helpQuestion: string;
   inputPlaceholder: string;
   commonQuestions: {
     [key: string]: string;
   };
+  assistantId?: number;
+  assistantName?: string;
+  assistantDescription?: string;
 }
 
 export type ChatType = keyof typeof chatDictionaries.nl;
@@ -33,11 +33,16 @@ interface ChatEmployee {
 }
 
 export function getChatEmployees(locale: SupportedLocale): ChatEmployee[] {
-  return Object.entries(chatDictionaries[locale] as unknown as Record<string, ChatSpecificDictionary>).map(([chatKey, chatEmployee]) => {
-    return {
-      id: getLocalizedPath(chatKey, locale),
-      name: chatEmployee.assistantName,
-      description: chatEmployee.assistantDescription,
-    };
-  });
+  return Object.entries(chatDictionaries[locale] as unknown as Record<string, ChatSpecificDictionary>)
+    .map(([chatKey, chatEmployee]) => {
+      if (!chatEmployee.assistantName || !chatEmployee.assistantDescription) {
+        return null;
+      }
+      return {
+        id: getLocalizedPath('chat/' + chatKey, locale),
+        name: chatEmployee.assistantName,
+        description: chatEmployee.assistantDescription,
+      };
+    })
+    .filter((employee): employee is ChatEmployee => employee !== null);
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,7 +12,7 @@ export default async function NotFound() {
     <main className="relative flex-1 flex flex-col pt-20">
       <Header dict={dict} />
       <div className="flex-1 overflow-y-auto">
-        <div className="max-w-5xl mx-auto px-6 py-12">
+        <div className="max-w-5xl mx-auto px-6 py-12 flex justify-center h-full">
           <NotFoundSection />
         </div>
       </div>

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -104,13 +104,13 @@ export default function ChatWindow({ dict }: { dict: any }) {
               >
                 {dict.commonQuestions.businessStructure}
               </Button>
-              <Button
+              {/* <Button
                 variant="outline"
                 className="rounded-full"
                 onClick={() => handleStartChat(dict.commonQuestions.more)}
               >
                 {dict.commonQuestions.more}
-              </Button>
+              </Button> */}
             </div>
 
             <p className="text-gray-500 mb-12 text-xs whitespace-pre-line">

--- a/components/sections/PartnersSection.tsx
+++ b/components/sections/PartnersSection.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
+import Link from "next/link";
 
 interface Partner {
   src: string;
   alt: string;
   width: number;
+  url: string;
 }
 
 interface PartnersSectionProps {
@@ -23,13 +25,15 @@ export default function PartnersSection({
           (image, index) =>
             image.src && (
               <div key={index} className="h-6">
-                <Image
-                  src={image.src || "/placeholder.svg"}
-                  alt={image.alt}
-                  width={image.width}
-                  height={24}
-                  className="h-full w-auto"
-                />
+                <Link href={image.url} target="_blank">
+                  <Image
+                    src={image.src || "/placeholder.svg"}
+                    alt={image.alt}
+                    width={image.width}
+                    height={24}
+                    className="h-full w-auto"
+                  />
+                </Link>
               </div>
             )
         )}

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -343,21 +343,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -449,21 +453,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -570,21 +578,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -677,21 +689,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -784,21 +800,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -905,21 +925,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1026,21 +1050,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1147,21 +1175,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1268,21 +1300,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1375,21 +1411,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1482,21 +1522,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1589,21 +1633,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1696,21 +1744,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]

--- a/dictionaries/nl.json
+++ b/dictionaries/nl.json
@@ -340,21 +340,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -446,21 +450,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -567,21 +575,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -674,21 +686,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -781,21 +797,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -902,21 +922,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1023,21 +1047,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1144,21 +1172,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1265,21 +1297,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1372,21 +1408,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1479,21 +1519,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1586,21 +1630,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]
@@ -1693,21 +1741,25 @@
           {
             "src": "https://jandebelastingman.nl/storage/media/b96c2cde-845a-4d93-93e9-4992fa9635f7.svg",
             "alt": "De Jurist",
+            "url": "https://dejurist.com/nieuws/50008411/kortgedingrechter-jan-de-belastingman-maakt-geen-inbreuk-op-handelsnaam-jan",
             "width": 100
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/9ca66407-c491-4096-8a53-a97625154fd4.svg",
             "alt": "Accountant",
+            "url": "https://www.accountant.nl/nieuws/2020/8/jan-moet-jan-de-belastingman-dulden",
             "width": 120
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/59b82e88-c24d-41c0-8380-6ae3d3420e48.svg",
+            "url": "https://www.quotenet.nl/nieuws/a33495849/sneu-accountantskantoor-jan-eist-duizenden-euros-student",
             "alt": "Quote",
             "width": 90
           },
           {
             "src": "https://jandebelastingman.nl/storage/media/1284cf24-5e7b-43aa-87cb-2ceb73ba7323.svg",
             "alt": "FD",
+            "url": "https://www.fd.nl/nieuws/2020/10/jan-de-belastingman-krijgt-kortgeding-van-student-die-zijn-naam-gebruikt-heeft~b4441f2b/?referrer=https%3A%2F%2Fjandebelastingman.test%2F&referrer=https%3A%2F%2Fjandebelastingman.nl%2F",
             "width": 60
           }
         ]

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -235,9 +235,14 @@ export function getLocalizedPath(path: string, locale: SupportedLocale): string 
 
   // Try to find the full path first in routes
   const fullPath = segments.join("/");
-  const routeEntry = routes[fullPath];
+  const nlRoutes = Object.keys(routes).filter((route) => routes[route].nl === fullPath);
+  const enRoutes = Object.keys(routes).filter((route) => routes[route].en === fullPath);
+  const routeEntry = nlRoutes[0] || enRoutes[0];
+
+
+  //const routeEntry = routes[fullPath];
   if (routeEntry) {
-    const localizedPath = routeEntry[locale];
+    const localizedPath = routes[routeEntry][locale];
     return locale === "en" ? `/en/${localizedPath}` : `/${localizedPath}`;
   }
 


### PR DESCRIPTION
Adds URLs for partner images in the Dutch and English dictionaries. 
Wraps images in a link for better accessibility and interaction. 
Updates routing logic to support localized paths more effectively.