### PR TITLE
feat: integrate chat dictionary for home page

### DIFF
--- a/app/chat/dictionaries.json
+++ b/app/chat/dictionaries.json
@@ -1,5 +1,24 @@
 {
   "nl": {
+    "home": {
+      "assistantId": 12,
+      "metadata": {
+        "title": "Jan de Belastingman | Your AI Tax Advisor",
+        "description": "Get instant answers to all your tax questions with our AI assistant. Professional, reliable, and available 24/7.",
+        "ogTitle": "Jan de Belastingman - AI Tax Advisor",
+        "ogDescription": "Ask your tax questions and get expert advice instantly from our AI assistant."
+      },
+      "helpQuestion": "Hoe kan ik je helpen?",
+      "inputPlaceholder": "Stel je vraag",
+      "commonQuestions": {
+        "deductions": "What deductions can I apply?",
+        "vatReturn": "How to file VAT returns as self-employed?",
+        "box3": "Do I need to declare assets in box 3?",
+        "businessStructure": "What's the impact of changing from sole proprietorship to LLC?"
+      },
+      "disclaimer": "This service is a digital assistant, not a certified tax advisor.\nNo rights can be derived from the provided information.",
+      "knownFrom": "As featured in"
+    },
     "income-tax-return": {
       "assistantId": 12,
       "metadata": {
@@ -192,6 +211,27 @@
     }
   },
   "en": {
+    "home": {
+      "assistantId": 12,
+      "metadata": {
+        "title": "Jan de Belastingman | Your AI Tax Advisor",
+        "description": "Get instant answers to all your tax questions with our AI assistant. Professional, reliable, and available 24/7.",
+        "ogTitle": "Jan de Belastingman - AI Tax Advisor",
+        "ogDescription": "Ask your tax questions and get expert advice instantly from our AI assistant."
+      },
+      "assistantName": "Jan de Belastingman",
+      "assistantDescription": "Tax assistent",
+      "helpQuestion": "How can I help you?",
+      "inputPlaceholder": "Ask your question",
+      "commonQuestions": {
+        "deductions": "What deductions can I apply?",
+        "vatReturn": "How to file VAT returns as self-employed?",
+        "box3": "Do I need to declare assets in box 3?",
+        "businessStructure": "What's the impact of changing from sole proprietorship to LLC?"
+      },
+      "disclaimer": "This service is a digital assistant, not a certified tax advisor.\nNo rights can be derived from the provided information.",
+      "knownFrom": "As featured in"
+    },
     "income-tax-return": {
       "assistantId": 12,
       "metadata": {

--- a/app/dictionaries/types.ts
+++ b/app/dictionaries/types.ts
@@ -124,6 +124,7 @@ interface Partner {
   src: string;
   alt: string;
   width: number;
+  url: string;
 }
 
 interface Step {

--- a/app/en/disclaimer/page.tsx
+++ b/app/en/disclaimer/page.tsx
@@ -48,36 +48,39 @@ export default async function PrivacyPage({ params, searchParams }: PageProps) {
   return (
     <main className="flex-1 flex flex-col relative">
       <Header dict={dict} />
-      <article className="max-w-4xl prose text-gray-500 mx-auto">
-        <h2>DISCLAIMER</h2>
-        <p>
-          Although the content of this website has been compiled with care,
-          jandebelastingman.nl cannot guarantee the accuracy or completeness of
-          the given (legal) information. Jandebelastingman.nl accepts no
-          liability for any damages, of whatever nature, arising in any way from
-          the use of the website and chatbot, including actions, omissions and /
-          or decisions based on such information, as well as the (temporary)
-          inability to use the website.
-          <br />
-          <br />
-          Jandebelastingman.nl accepts no liability for direct or indirect
-          damage caused by the content of the information on the website and
-          chatbot.
-          <br />
-          <br />
-          The information on these web pages and in the chatbot may contain
-          technical or typographical errors. This information may be changed or
-          expanded at any time without prior warning. Jandebelastingman.nl is in
-          no way responsible for other web pages that link to the
-          jandebelastingman.nl website.
-          <br />
-          <br />
-          The content of this website is checked as much as possible for its
-          content and topicality. If errors or inaccuracies would be published
-          we can not be held responsible. The information that the visitor of
-          our website reads can only be used at his own risk and responsibility.
-        </p>
-      </article>
+      <div className="flex-1 overflow-y-auto">
+        <article className="max-w-4xl prose text-gray-500 mx-auto px-6 py-12">
+          <h2>DISCLAIMER</h2>
+          <p>
+            Although the content of this website has been compiled with care,
+            jandebelastingman.nl cannot guarantee the accuracy or completeness
+            of the given (legal) information. Jandebelastingman.nl accepts no
+            liability for any damages, of whatever nature, arising in any way
+            from the use of the website and chatbot, including actions,
+            omissions and / or decisions based on such information, as well as
+            the (temporary) inability to use the website.
+            <br />
+            <br />
+            Jandebelastingman.nl accepts no liability for direct or indirect
+            damage caused by the content of the information on the website and
+            chatbot.
+            <br />
+            <br />
+            The information on these web pages and in the chatbot may contain
+            technical or typographical errors. This information may be changed
+            or expanded at any time without prior warning. Jandebelastingman.nl
+            is in no way responsible for other web pages that link to the
+            jandebelastingman.nl website.
+            <br />
+            <br />
+            The content of this website is checked as much as possible for its
+            content and topicality. If errors or inaccuracies would be published
+            we can not be held responsible. The information that the visitor of
+            our website reads can only be used at his own risk and
+            responsibility.
+          </p>
+        </article>
+      </div>
       <Footer dict={dict} />
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { generatePageMetadata } from "@/lib/metadata";
 import { SupportedLocale } from "@/lib/types";
 import { Metadata } from "next";
 import Header from "../components/Header";
+import { getChatDictionary } from "./chat/dictionary";
 import { getDictionary } from "./dictionaries";
 
 type PageParams = Promise<{
@@ -28,12 +29,14 @@ export default async function Home({ params }: PageProps) {
   const resolvedParams = await params;
   const locale = resolvedParams.locale || "nl";
   const dict = await getDictionary(locale);
+  const chatDict = getChatDictionary(locale, "home");
+  //const homeDict = dict.pages.home;
 
   return (
     <main className="relative flex-1 flex flex-col">
       <Header dict={dict} />
       <div className="flex-1 flex items-center justify-center">
-        <ChatWindow dict={dict.pages.home} />
+        <ChatWindow dict={chatDict} />
       </div>
       <Footer dict={dict} />
     </main>

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -9,27 +9,7 @@
     "twitterDescription": "Instant answers to all your tax questions with our AI assistant."
   },
   "pages": {
-    "home": {
-      "assistantId": 12,
-      "metadata": {
-        "title": "Jan de Belastingman | Your AI Tax Advisor",
-        "description": "Get instant answers to all your tax questions with our AI assistant. Professional, reliable, and available 24/7.",
-        "ogTitle": "Jan de Belastingman - AI Tax Advisor",
-        "ogDescription": "Ask your tax questions and get expert advice instantly from our AI assistant."
-      },
-      "assistantName": "Jan de Belastingman",
-      "assistantDescription": "Tax assistent",
-      "helpQuestion": "How can I help you?",
-      "inputPlaceholder": "Ask your question",
-      "commonQuestions": {
-        "deductions": "What deductions can I apply?",
-        "vatReturn": "How to file VAT returns as self-employed?",
-        "box3": "Do I need to declare assets in box 3?",
-        "businessStructure": "What's the impact of changing from sole proprietorship to LLC?"
-      },
-      "disclaimer": "This service is a digital assistant, not a certified tax advisor.\nNo rights can be derived from the provided information.",
-      "knownFrom": "As featured in"
-    },
+    "home": {},
     "how-it-works": {
       "title": "How does Jan de Belastingman work?",
       "items": [

--- a/dictionaries/nl.json
+++ b/dictionaries/nl.json
@@ -9,24 +9,7 @@
     "twitterDescription": "Instant answers to all your tax questions with our AI assistant."
   },
   "pages": {
-    "home": {
-      "metadata": {
-        "title": "Jan de Belastingman | Your AI Tax Advisor",
-        "description": "Get instant answers to all your tax questions with our AI assistant. Professional, reliable, and available 24/7.",
-        "ogTitle": "Jan de Belastingman - AI Tax Advisor",
-        "ogDescription": "Ask your tax questions and get expert advice instantly from our AI assistant."
-      },
-      "helpQuestion": "Hoe kan ik je helpen?",
-      "inputPlaceholder": "Stel je vraag",
-      "commonQuestions": {
-        "deductions": "What deductions can I apply?",
-        "vatReturn": "How to file VAT returns as self-employed?",
-        "box3": "Do I need to declare assets in box 3?",
-        "businessStructure": "What's the impact of changing from sole proprietorship to LLC?"
-      },
-      "disclaimer": "This service is a digital assistant, not a certified tax advisor.\nNo rights can be derived from the provided information.",
-      "knownFrom": "As featured in"
-    },
+    "home": {},
     "how-it-works": {
       "title": "How does Jan de Belastingman work?",
       "items": [


### PR DESCRIPTION
Update the chat window to use a new chat dictionary tailored for the  home page. This change enhances user interaction by providing specific  responses and metadata relevant to the home context. The previous  dictionary entries are removed for the English locale, as the chat  logic now relies solely on the localized dictionary.