### PR TITLE
feat: update chat session management and type definitions

### DIFF
--- a/lib/chat-stream.ts
+++ b/lib/chat-stream.ts
@@ -81,8 +81,8 @@ export async function* sendMessage({
   assistantId,
 }: {
   message: string;
-  chatSessionId?: number;
-  parentMessageId?: number;
+    chatSessionId?: string;
+    parentMessageId?: string;
     assistantId: number;
 }) {
   if (!chatSessionId || !parentMessageId) {
@@ -159,6 +159,6 @@ export type Message = {
   role: "user" | "assistant";
   content: string;
   timestamp: Date;
-  chatSessionId?: number;
-  parentMessageId?: number;
+  chatSessionId?: string;
+  parentMessageId?: string;
 }; 


### PR DESCRIPTION
Update the chat session state management to handle message IDs 
more effectively. Change the types of `chatSessionId` and 
`parentMessageId` from `number` to `string` to accommodate 
the incoming data structure. Introduce a new variable for 
tracking the latest message ID and update the session state 
when a new chat session ID is received. This improves 
consistency in message handling and tracking within the chat 
interface.