### PR TITLE
refactor: make SectionTitle optional in StepsSection

### DIFF
--- a/components/sections/StepsSection.tsx
+++ b/components/sections/StepsSection.tsx
@@ -10,7 +10,7 @@ interface Step {
 }
 
 interface StepsSectionProps {
-  SectionTitle: string;
+  SectionTitle?: string;
   steps: Step[];
   buttonText: string;
   buttonLink: string;
@@ -26,9 +26,9 @@ export default function StepsSection({
 }: StepsSectionProps) {
   return (
     <div>
-      <h2 className="text-2xl font-bold text-center mb-12">
-        {SectionTitle}
-      </h2>
+      {SectionTitle && (
+        <h2 className="text-2xl font-bold text-center mb-12">{SectionTitle}</h2>
+      )}
       <div className="space-y-16">
         {steps.map((step, index) => (
           <div key={index} className="grid md:grid-cols-2 gap-12 items-center">


### PR DESCRIPTION
Update StepsSection to optionally render SectionTitle. The title  is now a string property that can be omitted, allowing for  greater flexibility in usage. This change prevents rendering  issues when the title is not provided.