### PR TITLE
feat: add GTMProvider for tracking integration

### DIFF
--- a/app/components/providers/gtm-provider.tsx
+++ b/app/components/providers/gtm-provider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTracking } from "@/app/components/providers/tracking-provider";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    dataLayer: any[];
+  }
+}
+
+export function GTMProvider({ children }: { children: React.ReactNode }) {
+  const { trackingData } = useTracking();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!trackingData) return;
+
+    // Initialize dataLayer
+    window.dataLayer = window.dataLayer || [];
+
+    // Push initial tracking data
+    window.dataLayer.push({
+      event: "tracking_initialized",
+      tracking_id: trackingData.trackingId,
+      lead_source: trackingData.leadSource,
+      utm_params: trackingData.utmParams,
+      page_path: pathname,
+      timestamp: trackingData.timestamp,
+    });
+  }, [trackingData, pathname]);
+
+  return <>{children}</>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import Script from "next/script";
 import SidebarLayout from "../components/SidebarLayout";
+import { GTMProvider } from "./components/providers/gtm-provider";
 import { TrackingProvider } from "./components/providers/tracking-provider";
 import "./globals.css";
 
@@ -28,7 +29,6 @@ export const metadata: Metadata = {
   title: "Jan de Belastingman",
   description: "Belasting advies via AI",
 };
-
 
 export default function RootLayout({
   children,
@@ -66,7 +66,9 @@ export default function RootLayout({
           />
         </noscript>
         <TrackingProvider>
-          <SidebarLayout>{children}</SidebarLayout>
+          <GTMProvider>
+            <SidebarLayout>{children}</SidebarLayout>
+          </GTMProvider>
         </TrackingProvider>
       </body>
     </html>

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -163,6 +163,7 @@ export function ChatInterface({
                 });
               }
             } else if (Object.hasOwn(chunk, "tool_call") && chunk.tool_call) {
+              console.log("tool_call", chunk.tool_call);
               window.dataLayer = window.dataLayer || [];
               window.dataLayer.push({
                 event: "toolCall",


### PR DESCRIPTION
Implement GTMProvider to manage Google Tag Manager tracking data. 
Integrate GTMProvider in RootLayout to push initial tracking data 
into the dataLayer, enhancing analytics and tracking capabilities. 
Add logging for tool_call events in ChatInterface for better 
debugging and monitoring of user interactions.