### PR TITLE
fix: update default localized path and enhance cursor style

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -67,7 +67,7 @@ export function LanguageSwitcher() {
       <DropdownMenuContent align="end">
         <DropdownMenuItem
           onClick={() => handleLanguageChange("nl")}
-          className="flex items-center gap-2"
+          className="flex items-center gap-2 cursor-pointer"
         >
           <NLFlag />
           <span className={language === "nl" ? "font-bold" : ""}>
@@ -76,7 +76,7 @@ export function LanguageSwitcher() {
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => handleLanguageChange("en")}
-          className="flex items-center gap-2"
+          className="flex items-center gap-2 cursor-pointer"
         >
           <GBFlag />
           <span className={language === "en" ? "font-bold" : ""}>English</span>

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -222,7 +222,7 @@ export function getLocalizedPath(path: string, locale: SupportedLocale): string 
 
   // If path is just the locale or empty, return /
   if (cleanPath === "" || cleanPath === locale) {
-    return "/";
+    return "/en";
   }
 
   // Split path into segments


### PR DESCRIPTION
Set the default localized path to "/en" instead of "/" for better 
locale handling. Add cursor pointer style to language switcher 
dropdown items for improved user experience and indication of 
interactivity.