### PR TITLE
refactor: update parseReferrer to return string type

### DIFF
--- a/app/lib/tracking.ts
+++ b/app/lib/tracking.ts
@@ -35,7 +35,7 @@ export interface TrackingData {
   timestamp: number;
 }
 
-export function parseReferrer(referrer: string): LeadSource {
+export function parseReferrer(referrer: string): string {
   if (!referrer) return 'direct';
 
   return referrer || 'unknown';


### PR DESCRIPTION
Changes the return type of the parseReferrer function from  LeadSource to string. This improves clarity in type  expectations for consumers of the function, simplifying  the handling of return values.