### PR TITLE
fix: rename tracking_id to transaction_id for consistency

### DIFF
--- a/app/components/providers/gtm-provider.tsx
+++ b/app/components/providers/gtm-provider.tsx
@@ -24,7 +24,7 @@ export function GTMProvider({ children }: { children: React.ReactNode }) {
     // Push initial tracking data
     window.dataLayer.push({
       event: "tracking_initialized",
-      tracking_id: trackingData.trackingId,
+      transaction_id: trackingData.trackingId,
       lead_source: trackingData.leadSource,
       utm_params: trackingData.utmParams,
       hotjar_user_id: trackingData.hotjarUserId,

--- a/components/DynamicForm.tsx
+++ b/components/DynamicForm.tsx
@@ -404,7 +404,7 @@ export function DynamicForm({ handle, className }: DynamicFormProps) {
           form_name: formData?.name,
           //form_data: visibleValues,
           language: isEnglish ? "en" : "nl",
-          tracking_id: trackingData?.trackingId,
+          transaction_id: trackingData?.trackingId,
           lead_source: trackingData?.leadSource,
           utm_params: trackingData?.utmParams,
           gad_source: trackingData?.gadSource,

--- a/components/forms/dynamic-form.tsx
+++ b/components/forms/dynamic-form.tsx
@@ -307,7 +307,7 @@ export function DynamicForm({
             ecommerce: {
               form_handle: formData.id,
               language: locale,
-              tracking_id: trackingData?.trackingId,
+              transaction_id: trackingData?.trackingId,
               lead_source: trackingData?.leadSource,
               utm_params: trackingData?.utmParams,
               hotjar_user_id: trackingData?.hotjarUserId,


### PR DESCRIPTION
Update instances of tracking_id to transaction_id in GTMProvider and 
DynamicForm components. This change ensures consistency in naming 
conventions across the codebase and improves clarity in tracking data 
handling.