### PR TITLE
feat: implement honeypot for bot detection in forms

### DIFF
--- a/components/DynamicForm.tsx
+++ b/components/DynamicForm.tsx
@@ -288,6 +288,9 @@ export function DynamicForm({ handle, className }: DynamicFormProps) {
     reValidateMode: "onSubmit",
   });
 
+  // Add honeypot field to the form
+  const honeypotField = "contact_phone"; // Changed to a different common field name that bots might try to fill
+
   // Get all condition fields from the form data
   const getConditionFields = useCallback(() => {
     if (!formData) return new Set<string>();
@@ -355,6 +358,13 @@ export function DynamicForm({ handle, className }: DynamicFormProps) {
     locale: string
   ) => {
     try {
+      // Check honeypot field
+      if (values[honeypotField]) {
+        // If honeypot is filled, silently fail
+        console.log("Bot detected - honeypot field filled");
+        return;
+      }
+
       const formValues = form.getValues();
       const visibleFields = new Set<string>();
 
@@ -747,6 +757,16 @@ export function DynamicForm({ handle, className }: DynamicFormProps) {
         )}
         className={cn("space-y-4", className)}
       >
+        {/* Add honeypot field */}
+        <div className="hidden">
+          <input
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            {...form.register(honeypotField)}
+          />
+        </div>
+
         {formData.form_sections.map((section, index) => (
           <div
             key={index}

--- a/components/forms/dynamic-form.tsx
+++ b/components/forms/dynamic-form.tsx
@@ -249,6 +249,9 @@ export function DynamicForm({
     mode: "onSubmit",
   });
 
+  // Add honeypot field to the form
+  const honeypotField = "company_name"; // Common field name that bots might try to fill
+
   const _handleNextPage = useCallback(
     (e?: React.MouseEvent<HTMLButtonElement>) => {
       e?.preventDefault();
@@ -278,6 +281,13 @@ export function DynamicForm({
     async (values: any): Promise<boolean> => {
       if (currentPage < totalPages) {
         _handleNextPage();
+        return false;
+      }
+
+      // Check honeypot field
+      if (values[honeypotField]) {
+        // If honeypot is filled, silently fail
+        console.log("Bot detected - honeypot field filled");
         return false;
       }
 
@@ -770,6 +780,16 @@ export function DynamicForm({
               onSubmit={form.handleSubmit(handleSubmit)}
               className="space-y-8"
             >
+              {/* Add honeypot field */}
+              <div className="hidden">
+                <input
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  {...form.register(honeypotField)}
+                />
+              </div>
+
               {safeConfig.sections && safeConfig.sections.length > 0 ? (
                 safeConfig.sections
                   .filter((section) => (section.page || 1) === currentPage)
@@ -813,9 +833,18 @@ export function DynamicForm({
                         <div className="space-y-1 leading-none">
                           <FormLabel>
                             {locale === "en" ? (
-                              <>I have read the <Link href="/en/privacy">privacy policy</Link> and consent to being contacted.</>
+                              <>
+                                I have read the{" "}
+                                <Link href="/en/privacy">privacy policy</Link>{" "}
+                                and consent to being contacted.
+                              </>
                             ) : (
-                              <>Ik heb het <Link href="/privacy">privacybeleid</Link> gelezen en ga ermee akkoord dat er contact met mij wordt opgenomen.</>
+                              <>
+                                Ik heb het{" "}
+                                <Link href="/privacy">privacybeleid</Link>{" "}
+                                gelezen en ga ermee akkoord dat er contact met
+                                mij wordt opgenomen.
+                              </>
                             )}
                             <span className="text-destructive ml-1">*</span>
                           </FormLabel>


### PR DESCRIPTION
Add a honeypot field named "company_name" to the dynamic form to help  detect and prevent spam submissions from bots. Update the form's  submission logic to check if this field is filled, and silently  fail if it is. Additionally, enhance the user interface by  separating the privacy policy consent message for improved clarity.